### PR TITLE
Generate article summaries using gemini 

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -8,3 +8,5 @@ flask --debug run
 
 Environment variables:
 MONGO_URI
+NEWS_API_KEY
+GEMINI_API_KEY

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -2,8 +2,10 @@ from flask import Blueprint, jsonify, request
 from app.database import mongo
 from app.schemas import article_schema
 from datetime import datetime
+from app.services.news_api import NewsApi
 
 main = Blueprint("main", __name__)
+news_api = NewsApi()
 @main.route('/')
 def home():
     return "Hello, Flask!"
@@ -78,6 +80,8 @@ def insert_article():
     
 @main.route('/api/delete_all_articles', methods=['DELETE'])
 def delete_all():
+
+
     '''
     Delete all articles in the articles collection in briefly.
     '''
@@ -89,6 +93,28 @@ def delete_all():
             "deletedCount" : count,
             "message": "All articles deleted"
         })
+    except Exception as e:
+        return jsonify({
+            "success" : False,
+            "error": str(e)
+        })
+
+@main.route('/api/generate_articles', methods=['GET', 'POST'])
+def generate_articles():
+    try:
+        content_type = request.headers.get('Content-Type')
+        if content_type == 'application/json':
+            data = request.get_json()
+        elif content_type == 'application/x-www-form-urlencoded':
+            data = request.form.to_dict()
+        else:
+            return jsonify({"error": "Unsupported Content-Type"})
+        
+        if not isinstance(data, dict):
+            return jsonify({"error": "Invalid data"})
+        
+        result = news_api.get_articles(params=data)
+        return result
     except Exception as e:
         return jsonify({
             "success" : False,

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -1,11 +1,19 @@
 from marshmallow import Schema, fields, INCLUDE
 
+class SummarizationSchema(Schema):
+    summary = fields.Str(required=True)
+    key_points = fields.List(fields.Str, required=True)
+
 class ArticleSchema(Schema):
     class Meta:
         unknown = INCLUDE
         
     id = fields.Str(dump_only=True, attribute='_id')
     title = fields.Str(required=True)
-    summary = fields.Str(required=True)
+    author = fields.Str()
+    published_date = fields.DateTime()
+    url = fields.Url(required=True)
+    summarization = fields.Nested(SummarizationSchema)
+
 
 article_schema = ArticleSchema()

--- a/server/app/services/gemini.py
+++ b/server/app/services/gemini.py
@@ -1,0 +1,32 @@
+import os, json
+from google import genai
+from dotenv import load_dotenv
+from flask import jsonify
+
+load_dotenv()
+
+client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
+
+class AI():
+    def __init__(self, client):
+        self.client = client
+        self.prompt = "You are a JSON only reponse generator. Always respond with valid JSON that matches the user's requested schema." +\
+        " Never include explanations or non-JSON text in your responses." +\
+        "Summarize this article into one paragraph and include a key points section with bullet points." +\
+        "In the key points section, only include the main points of the article. " +\
+        "Return as a JSON object. Here is the JSON schema: " +\
+        "Summary = {{'summary': str, 'key_points' : list[str]}}, " +\
+        "Here is the article: "
+
+    def summarize_article(self, content):
+        query = self.prompt + content
+        response = client.models.generate_content(
+            model="gemini-2.0-flash", contents=query
+        )
+        clean_json = response.text.replace("```json", "").replace("```", "").strip() #remove from gemini response
+        return jsonify({
+            "success": True,
+            "summarization" : json.loads(clean_json),
+        })
+
+ai_client = AI(client)

--- a/server/app/services/news_api.py
+++ b/server/app/services/news_api.py
@@ -1,26 +1,54 @@
 import os, json
 import requests #different from flask request
 from flask import jsonify
+from dotenv import load_dotenv
+
+load_dotenv()
 
 class NewsApi:
     BASE_URL = "https://newsapi.org/v2/"
     def __init__(self):
-        self.api_key = os.getenv("NEWS_API_KEY")
+        self.api_key = os.environ.get("NEWS_API_KEY")
         
     def get_articles(self, params=None):
         '''
-        Fetch articles from the News API.'
+        Fetch articles from the News API.
+        Parameters: params 
         '''
         try:
             header = {"Authorization": self.api_key}
-            #response = requests.get(f"{self.BASE_URL}/everything?", params=params, headers=header)
+            response = requests.get(f"{self.BASE_URL}/everything?", params=params, headers=header)
 
             #file with dummy data to avoid repeated news_api calls
-            f = open('dummy.json', encoding="utf-8")
-            response = json.load(f)
-            print(params)
+            #f = open('dummy.json', encoding="utf-8")
+            #response = json.load(f)
+
+            #print(json.loads(response.text))
+            result_json = json.loads(response.text) #converts the json string to json
+            articles = result_json["articles"] #list of articles from news_api
+            processed_data = process_articles(articles)
+
             return jsonify({
-            "message": "testing"
+                "success": True,
+                "num_articles" : len(processed_data),
+                "processed_articles" : processed_data
             })
         except Exception as e:
             return {"error": str(e)}
+        
+def process_articles(articles):
+    '''
+    Takes the list of articles from News API, processes the data by getting the
+    url, title, author, published date. Returns a list of JSON objects that contain
+    these fields
+    '''
+    processed_articles = [] #list of json objs to return
+    for article in articles: 
+        p_article = {
+            "title": article["title"],
+            "author": article["author"],
+            "published_date": article["publishedAt"],
+            "url": article["url"]
+        }
+        processed_articles.append(p_article)
+    return processed_articles

--- a/server/app/services/news_api.py
+++ b/server/app/services/news_api.py
@@ -1,0 +1,26 @@
+import os, json
+import requests #different from flask request
+from flask import jsonify
+
+class NewsApi:
+    BASE_URL = "https://newsapi.org/v2/"
+    def __init__(self):
+        self.api_key = os.getenv("NEWS_API_KEY")
+        
+    def get_articles(self, params=None):
+        '''
+        Fetch articles from the News API.'
+        '''
+        try:
+            header = {"Authorization": self.api_key}
+            #response = requests.get(f"{self.BASE_URL}/everything?", params=params, headers=header)
+
+            #file with dummy data to avoid repeated news_api calls
+            f = open('dummy.json', encoding="utf-8")
+            response = json.load(f)
+            print(params)
+            return jsonify({
+            "message": "testing"
+            })
+        except Exception as e:
+            return {"error": str(e)}

--- a/server/app/services/scraper.py
+++ b/server/app/services/scraper.py
@@ -1,0 +1,34 @@
+from bs4 import BeautifulSoup
+import requests, json
+from flask import jsonify
+
+'''
+sites with paywalls:
+wired.com
+
+sites formatted:
+verge.com ({site: 'p', class_="duet--article--dangerously-set-cms-markup duet--article--standard-paragraph _1ymtmqpi _17nnmdy1 _17nnmdy0 _1xwtict1"})
+'''
+
+'''
+function currently works with 1 url and verge.com
+'''
+def scrape_article(url):
+    '''
+    Scrapes article content given url
+    Returns: 
+    '''
+    try:
+        response = requests.get(url)
+        soup = BeautifulSoup(response.content, "html.parser")
+        paragraphs = soup.find_all('p', class_="duet--article--dangerously-set-cms-markup duet--article--standard-paragraph _1ymtmqpi _17nnmdy1 _17nnmdy0 _1xwtict1")
+        content = ""
+        for p in paragraphs:
+            content += p.text
+        return jsonify({
+            "success" : True,
+            "url" : json.dumps(url),
+            "content" : content
+        })
+    except Exception as e:
+        return {"error": str(e)}

--- a/server/app/services/utils.py
+++ b/server/app/services/utils.py
@@ -24,6 +24,4 @@ def scrape_summarize(response):
         response = ai_client.summarize_article(content) #jsonify object returned from summarize_article
         summary_data = json.loads(response.data) #converting jsonify object to dict
         article['summarization'] = summary_data['summarization'] #setting a new field for each article
-
-    return data 
-        
+    return data   

--- a/server/app/services/utils.py
+++ b/server/app/services/utils.py
@@ -1,0 +1,29 @@
+import json
+from app.services.scraper import scrape_article
+from app.services.gemini import ai_client
+def scrape_summarize(response):
+    '''
+    Function that scrapes article content and summarizes it
+    -Gets the url from each article, calls scrape_article with it
+    -Scrape article returns a jsonify object that has: success, url, content
+    -The content field holds a string that is the full content of the article
+    -Sends content to summarize_article which uses gemini to summarize the content
+    -A jsonify object is returned with fields: success, summarization : {summary, keypoints}
+    -Set a new field summarization to the generated summary
+    -Return the original data with a newly added summarization field
+    Parameters:
+    response: Flask jsonify object containing the fields: success, num_articles, processed_articles
+    '''
+    data = json.loads(response.data)
+    articles = data['processed_articles']
+    for article in articles:
+        article_url = article['url']
+        result = scrape_article(article_url) #returns a jsonify object that contains {"content" : <scraped data>}
+        result_json = json.loads(result.data) # converting jsonify object to a dict
+        content = result_json['content'] #extacting article content
+        response = ai_client.summarize_article(content) #jsonify object returned from summarize_article
+        summary_data = json.loads(response.data) #converting jsonify object to dict
+        article['summarization'] = summary_data['summarization'] #setting a new field for each article
+
+    return data 
+        

--- a/server/dummy.json
+++ b/server/dummy.json
@@ -1,0 +1,1254 @@
+{
+    "status": "ok",
+    "totalResults": 13960,
+    "articles": [
+        {
+            "source": {
+                "id": "the-verge",
+                "name": "The Verge"
+            },
+            "author": "Andrew J. Hawkins",
+            "title": "Is Tesla cooked?",
+            "description": "Tesla stock plunged 15 percent on Monday, its steepest drop in five years. The price is down over 50 percent since its December highs. Tesla owners, disgusted with Elon Muskâs slash-and-burn tactics for the Trump administration, are selling their vehicles a…",
+            "url": "https://www.theverge.com/tesla/627894/tesla-stock-sales-protest-musk-trump-doge",
+            "urlToImage": "https://platform.theverge.com/wp-content/uploads/sites/2/2025/03/STK022_ELON_MUSK_4_CVIRGINIA_B.webp?quality=90&strip=all&crop=0%2C10.732984293194%2C100%2C78.534031413613&w=1200",
+            "publishedAt": "2025-03-11T22:17:04Z",
+            "content": "The CEO is absent, the stocks are plummeting, and the brand is toxic. Teslas future looks grim. \r\nThe CEO is absent, the stocks are plummeting, and the brand is toxic. Teslas future looks grim. \r\nTes… [+10200 chars]"
+        },
+        {
+            "source": {
+                "id": "the-verge",
+                "name": "The Verge"
+            },
+            "author": "Andrew J. Hawkins",
+            "title": "The Cybertruck is the latest Tesla to score a 5-star crash rating",
+            "description": "The Tesla Cybertruck finally has its first crash safety rating over a year after deliveries first began in November 2023. And like all other Tesla vehicles before it, the electric truck scored a 5-star rating in nearly all the individual categories. The categ…",
+            "url": "https://www.theverge.com/news/615262/the-cybertruck-is-latest-tesla-to-score-a-5-star-crash-rating",
+            "urlToImage": "https://platform.theverge.com/wp-content/uploads/sites/2/chorus/uploads/chorus_asset/file/25830320/STKS493_CYBERTRUCK_CVIRGINIA_B.jpg?quality=90&strip=all&crop=0%2C10.732984293194%2C100%2C78.534031413613&w=1200",
+            "publishedAt": "2025-02-19T16:00:39Z",
+            "content": "The angular electric truck was put through a battery of tests to simulate head-on and side crashes, as well as rollovers.\r\nThe angular electric truck was put through a battery of tests to simulate he… [+3228 chars]"
+        },
+        {
+            "source": {
+                "id": "wired",
+                "name": "Wired"
+            },
+            "author": "Aarian Marshall",
+            "title": "Tesla Got a Permit to Operate a Taxi Service in California—but There's a Catch",
+            "description": "The taxi service will initially operate with Tesla employee drivers only, use current-model vehicles, and won't allow for driverless rides.",
+            "url": "https://www.wired.com/story/tesla-got-a-permit-to-operate-a-taxi-service-in-california-but-theres-a-catch/",
+            "urlToImage": "https://media.wired.com/photos/67d9e302de323b7691481579/191:100/w_1280,c_limit/Gear_Cybercab_GettyImages-2193378832.jpg",
+            "publishedAt": "2025-03-18T21:53:25Z",
+            "content": "Tesla has been granted a permit to operate a taxi service in California, a spokesperson for the California Public Utilities Commission, a state regulator, said Tuesday. It marks the first step toward… [+3418 chars]"
+        },
+        {
+            "source": {
+                "id": "the-verge",
+                "name": "The Verge"
+            },
+            "author": "Andrew J. Hawkins",
+            "title": "Ford’s Tesla Supercharger adapters are now on sale for $200",
+            "description": "Ford is making some changes to how it handles its EV charging accessories. The company was the first to announce its plans to adopt Tesla’s North American Charging Standard (NACS) connector for its EVs, and was also first to distribute NACS adapters to its EV…",
+            "url": "https://www.theverge.com/news/627230/ford-nacs-adapter-tesla-supercharger-price",
+            "urlToImage": "https://platform.theverge.com/wp-content/uploads/sites/2/2025/03/Ford-Charging-Adapter_Connecting.jpg?quality=90&strip=all&crop=0%2C10.732984293194%2C100%2C78.534031413613&w=1200",
+            "publishedAt": "2025-03-10T22:23:54Z",
+            "content": "Ford has dealt with delays and supply shortages in getting NACS adapters to customers.\r\nFord has dealt with delays and supply shortages in getting NACS adapters to customers.\r\nFord is making some cha… [+2338 chars]"
+        },
+        {
+            "source": {
+                "id": "the-verge",
+                "name": "The Verge"
+            },
+            "author": "Andrew J. Hawkins",
+            "title": "Tesla Superchargers coming to dozens of Steak ‘n Shake locations",
+            "description": "Tesla is planning to install dozens of Supercharger sites at Steak ‘n Shake locations across the country, according to an exchange between the companies on X. The companies have signed an agreement for over six sites, with over 20 more to come. And if Steak ‘…",
+            "url": "https://www.theverge.com/news/621810/tesla-supercharger-steak-n-shake-partnership",
+            "urlToImage": "https://platform.theverge.com/wp-content/uploads/sites/2/2025/02/gettyimages-2193195652.jpg?quality=90&strip=all&crop=0%2C10.484351094599%2C100%2C79.031297810802&w=1200",
+            "publishedAt": "2025-02-28T19:31:25Z",
+            "content": "Tesla is planning to install dozens of Supercharger sites at Steak ‘n Shake locations across the country, according to an exchange between the companies on X. The companies have signed an agreement f… [+1851 chars]"
+        },
+        {
+            "source": {
+                "id": "wired",
+                "name": "Wired"
+            },
+            "author": "Aarian Marshall",
+            "title": "Ford Is Sticking With an EV Future",
+            "description": "CEO Jim Farley tells us that every qualified owner of a Ford electric car has received an adaptor that allows them to charge up at Tesla-operated Supercharger stations.",
+            "url": "https://www.wired.com/story/ford-ev-charging-adapters-for-tesla-superchargers/",
+            "urlToImage": "https://media.wired.com/photos/67cef3290b79bb0f653a06c3/191:100/w_1280,c_limit/Ford%20Charging%20Adapter_Mustang%20Mach-E_2_.jpg",
+            "publishedAt": "2025-03-11T12:00:00Z",
+            "content": "The road to progress has never been smooth. Witness, as a metaphor, the trials and tribulations of the Ford Motor Company as it has tried to sell electric vehicle drivers the premier charging experie… [+3080 chars]"
+        },
+        {
+            "source": {
+                "id": "wired",
+                "name": "Wired"
+            },
+            "author": "Jeremy White",
+            "title": "Donald Trump Bought a $90,000 Tesla With 37 Recall Notices Against It",
+            "description": "Here's hoping Elon Musk won't have to personally fix President Trump's new EV anytime soon.",
+            "url": "https://www.wired.com/story/donald-trump-bought-a-dollar90000-tesla-with-37-recall-notices-against-it/",
+            "urlToImage": "https://media.wired.com/photos/67d1b556d38aff896fec27be/191:100/w_1280,c_limit/trump-tesla-gear-2204588044.jpg",
+            "publishedAt": "2025-03-12T16:45:25Z",
+            "content": "Likely referring to the significant negative coverage of Musk's efforts leading the so-called Department of Government Efficiency (DOGE), the president committed to buying a Tesla via TruthSocial on … [+2607 chars]"
+        },
+        {
+            "source": {
+                "id": "the-verge",
+                "name": "The Verge"
+            },
+            "author": "Andrew J. Hawkins",
+            "title": "Tesla Cybertruck deliveries reportedly on hold because the trim is flying off",
+            "description": "America’s favorite low poly electric truck is facing a new set of problems that don’t have anything to do with people spray painting swastikas or crude comments about Elon Musk on them. Deliveries of the Tesla Cybertruck are on hold while the company addresse…",
+            "url": "https://www.theverge.com/news/629352/tesla-cybertruck-deliveries-on-hold-loose-trim",
+            "urlToImage": "https://platform.theverge.com/wp-content/uploads/sites/2/chorus/uploads/chorus_asset/file/25830320/STKS493_CYBERTRUCK_CVIRGINIA_B.jpg?quality=90&strip=all&crop=0%2C10.732984293194%2C100%2C78.534031413613&w=1200",
+            "publishedAt": "2025-03-13T19:36:28Z",
+            "content": "America’s favorite low poly electric truck is facing a new set of problems that don’t have anything to do with people spray painting swastikas or crude comments about Elon Musk on them. Deliveries of… [+1951 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Matt Novak",
+            "title": "Tesla Fires Manager Who Complained About Elon Musk’s Nazi Jokes",
+            "description": "Musk rather amusingly calls himself a champion of free speech.",
+            "url": "https://gizmodo.com/tesla-fires-manager-who-complained-about-elon-musks-nazi-jokes-2000569640",
+            "urlToImage": "https://gizmodo.com/app/uploads/2025/01/elon-musk-nazi-salute.jpg",
+            "publishedAt": "2025-02-28T14:15:54Z",
+            "content": "Tesla has fired a manager after he wrote a LinkedIn post criticizing Elon Musk’s jokes about Nazis, according to a report from the New York Times. And it’s a great reminder that not only is Musk curr… [+2834 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Matthew Gault",
+            "title": "Tesla Hate Is Making Insurance More Expensive for Owners",
+            "description": "As stock slumps and Americans turn against the automaker, its owners are paying higher insurance premiums.",
+            "url": "https://gizmodo.com/tesla-hate-is-making-insurance-more-expensive-for-owners-2000577467",
+            "urlToImage": "https://gizmodo.com/app/uploads/2025/03/TeslaProtests.jpg",
+            "publishedAt": "2025-03-18T16:20:34Z",
+            "content": "Teslas are getting more expensive to insure thanks to the manufacturers sliding fortunes and reports of vandalism against the cars. There are few markets as pure, heartless, and single-minded as auto… [+3796 chars]"
+        },
+        {
+            "source": {
+                "id": "the-verge",
+                "name": "The Verge"
+            },
+            "author": "David Pierce",
+            "title": "The fake promise of better Siri",
+            "description": "Apple Intelligence is technically lots of things, but thereâs only one feature with the potential to actually meaningfully change the way you use your phone. That would be Siri, which Apple said last year it had turned from a quasi-helpful voice assistant i…",
+            "url": "https://www.theverge.com/the-vergecast/629652/siri-delay-bad-apple-tesla-trump-vergecast",
+            "urlToImage": "https://platform.theverge.com/wp-content/uploads/sites/2/2025/03/VST_0314_Site.jpg?quality=90&strip=all&crop=0%2C10.732984293194%2C100%2C78.534031413613&w=1200",
+            "publishedAt": "2025-03-14T12:50:21Z",
+            "content": "On The Vergecast: AI gadget failures, how Tesla became politics, and Sonoss TV dreams.\r\nOn The Vergecast: AI gadget failures, how Tesla became politics, and Sonoss TV dreams.\r\nApple Intelligence is t… [+2130 chars]"
+        },
+        {
+            "source": {
+                "id": "wired",
+                "name": "Wired"
+            },
+            "author": "Brian Barrett",
+            "title": "The United States of Elon Musk Inc.",
+            "description": "The degree to which Donald Trump and Elon Musk’s interests are intertwined is unprecedented—and ultimately unsustainable.",
+            "url": "https://www.wired.com/story/elon-musk-donald-trump-doge-congress-takeover/",
+            "urlToImage": "https://media.wired.com/photos/67d21b81e3dd1d52d70b101e/191:100/w_1280,c_limit/politics_newsletter_united_states_musk_inc.jpg",
+            "publishedAt": "2025-03-13T14:00:00Z",
+            "content": "Where do Elon Musks business interests end and Donald Trumps political interests begin? Trick questiontheyre one and the same.\r\nHow else do you explain the jarring sight of the President of the Unite… [+2965 chars]"
+        },
+        {
+            "source": {
+                "id": "the-verge",
+                "name": "The Verge"
+            },
+            "author": "Andrew J. Hawkins",
+            "title": "The Volkswagen ID. EVERY1 is an affordable EV for the masses",
+            "description": "Volkswagen is bringing up the lights on the ID. EVERY1 show car that it says will become the promised €20,000 (about $20,800 USD) affordable EV that will hopefully turn around the automaker’s struggling business.  As market leaders like Tesla continue to prom…",
+            "url": "https://www.theverge.com/news/624676/vw-id-every1-ev-price-range-specs-2027",
+            "urlToImage": "https://platform.theverge.com/wp-content/uploads/sites/2/2025/03/ID1_34front.jpg?quality=90&strip=all&crop=0%2C10.752696650476%2C100%2C78.494606699048&w=1200",
+            "publishedAt": "2025-03-05T17:07:10Z",
+            "content": "The sporty hatchback will sell for 20,000 when it launches in Europe in 2027. But when will we see it in the US?\r\nThe sporty hatchback will sell for 20,000 when it launches in Europe in 2027. But whe… [+4137 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Matt Novak",
+            "title": "How to Find Your Local Protest Against Elon Musk",
+            "description": "Many Americans are expressing their displeasure with the oligarch.",
+            "url": "https://gizmodo.com/how-to-find-your-local-protest-against-elon-musk-2000570035",
+            "urlToImage": "https://gizmodo.com/app/uploads/2025/02/Elon-Musk-protest-Feb-27-2025-.jpg",
+            "publishedAt": "2025-02-28T18:45:11Z",
+            "content": "Elon Musk has spent the past month destroying the U.S. federal government with his team of DOGE goons, taking a chainsaw to USAID, NOAA, Social Security, and countless other vital agencies. And while… [+3821 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Matthew Gault",
+            "title": "Lawmakers Demand Answers From Rubio Over the $400 Million Armored Tesla Contract",
+            "description": "A Senator and a Congressman have sent letters to the Secretary of State demanding he answer questions about a scandal that probably doesn’t exist.",
+            "url": "https://gizmodo.com/lawmakers-demand-answers-from-rubio-over-the-400-million-armored-tesla-contract-2000573841",
+            "urlToImage": "https://gizmodo.com/app/uploads/2022/04/f6565bafdba3fb884da94179c52f735e.jpg",
+            "publishedAt": "2025-03-10T16:10:32Z",
+            "content": "Politicians are pressing Secretary of State Marco Rubio to answer questions about a government contract for armored Teslas that never existed. Sen. Richard Blumenthal (D-NY) and Congressman Gregory M… [+6127 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Matt Novak",
+            "title": "Musk Plans to Give Trump Groups $100 Million After Tesla Ad at the White House",
+            "description": "The billionaire oligarch effectively controls the federal government right now.",
+            "url": "https://gizmodo.com/musk-plans-to-give-trump-groups-100-million-after-tesla-ad-at-the-white-house-2000575040",
+            "urlToImage": "https://gizmodo.com/app/uploads/2025/03/elon-musk-donald-trump-tesla-ad-white-house-flickr.jpg",
+            "publishedAt": "2025-03-12T17:40:09Z",
+            "content": "Elon Musk is planning to give $100 million to two political groups associated with President Donald Trump, according to a report from the New York Times. The move is unprecedented in American politic… [+5302 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "aaltchek@insider.com (Ana Altchek)",
+            "title": "It's crunch time for Tesla",
+            "description": "Tesla's lower-cost vehicle is supposed to begin production by June at the latest. Analysts tell BI the launch is \"crucial\" and a \"necessity.\"",
+            "url": "https://www.businessinsider.com/tesla-low-cost-cheaper-car-production-deadline-2025-3",
+            "urlToImage": "https://i.insider.com/67cf5fc7b8b41a9673fa3983?width=1200&format=jpeg",
+            "publishedAt": "2025-03-11T09:00:02Z",
+            "content": "Time is ticking for Tesla's promised lower-cost vehicle.\r\nThe electric car giant said in its most recent earnings call earlier this year that production for the long-awaited \"more affordable\" Tesla w… [+3181 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Thomas Maxwell",
+            "title": "BYD Says It Can Now Charge An Electric Car In 5 Minutes",
+            "description": "The Chinese automaker says it will start selling vehicles with the new battery system starting next month.",
+            "url": "https://gizmodo.com/byd-says-it-can-now-charge-an-electric-car-in-5-minutes-2000577651",
+            "urlToImage": "https://gizmodo.com/app/uploads/2025/03/GettyImages-2204058346.jpg",
+            "publishedAt": "2025-03-18T23:50:17Z",
+            "content": "Chinese automaker BYD continues to leave Tesla in the dust. The company introduced a new battery system on Monday that it claims can charge an electric vehicle in just five minutes, about the same ti… [+3432 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Grace Eliza Goodwin",
+            "title": "Trump says he's buying a Tesla to show support for Elon Musk",
+            "description": "Amid backlash and protests against Tesla, Donald Trump announces his intention to purchase a Tesla, showing support for Elon Musk and his ventures.",
+            "url": "https://www.businessinsider.com/donald-trump-buy-tesla-support-elon-musk-stock-protests-2025-3",
+            "urlToImage": "https://i.insider.com/67d046adb8b41a9673fa4392?width=1200&format=jpeg",
+            "publishedAt": "2025-03-11T14:34:35Z",
+            "content": "Demonstrators protesting against Elon Musk and electric car maker Tesla on February 22, 2025, in Seattle, Washington.David Ryder/Getty Images\r\n<ul><li>Donald Trump says he plans to buy a Tesla to sup… [+2268 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Ana Altchek",
+            "title": "Add Australia to the list of countries where Tesla sales are sliding",
+            "description": "Tesla sales dropped 71% year over year in Australia in February, joining a number of recent countries with slumping Tesla sales.",
+            "url": "https://www.businessinsider.com/tesla-sales-fall-australia-elon-musk-protests-2025-3",
+            "urlToImage": "https://i.insider.com/67d1a581585f1dff88b1e350?width=1200&format=jpeg",
+            "publishedAt": "2025-03-12T17:54:07Z",
+            "content": "Elon Musk is CEO of Tesla.Kayla Bartkowski/Getty Images\r\n<ul><li>Tesla sales in Australia fell 71% in February compared with the same month last year.</li><li>The drop comes as the country also exper… [+2156 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Tom Carter",
+            "title": "Tesla owners offloading their cars over Elon Musk backlash are in for a nasty surprise",
+            "description": "Resale values have collapsed in recent years, with the average price of a used Tesla now $10,000 less than that of a non-Tesla electric car.",
+            "url": "https://www.businessinsider.com/tesla-sale-big-losses-second-hand-value-plunge-elon-musk-2025-3",
+            "urlToImage": "https://i.insider.com/67d0088369253ccddf98d78e?width=1200&format=jpeg",
+            "publishedAt": "2025-03-11T11:42:55Z",
+            "content": "Demonstrators protest against Elon Musk and Tesla in Seattle last month.David Ryder/Getty Images\r\n<ul><li>Some Tesla owners are considering selling their cars as backlash against Elon Musk and DOGE g… [+3127 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Thibault Spirlet",
+            "title": "Activists used a Tesla to write 'Don't buy a Tesla' on a beach in Wales",
+            "description": "The UK group Led By Donkeys used a Tesla to etch the slogan in sand on a beach in Wales, urging drivers not to buy a car from Elon Musk's EV maker.",
+            "url": "https://www.businessinsider.com/elon-musk-tesla-activisits-protest-message-beach-led-by-donkeys-2025-3",
+            "urlToImage": "https://i.insider.com/67d9512eb8b41a9673faed38?width=1200&format=jpeg",
+            "publishedAt": "2025-03-18T13:18:53Z",
+            "content": "The beach message was created by UK activist group Led By Donkeys.Led By Donkeys\r\n<ul><li>Activists used a Tesla to draw a slogan reading \"Don't buy a Tesla\" on a beach in Wales.</li><li>The protest … [+3183 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "gkay@businessinsider.com (Grace Kay)",
+            "title": "Inside xAI's organizational chart: Who's in charge at Elon Musk's company",
+            "description": "The ranks include Elon Musk's home office manager, his son, and former Tesla and Google engineers.",
+            "url": "https://www.businessinsider.com/xai-org-chart-employees-elon-musk-direct-reports-2025-3",
+            "urlToImage": "https://i.insider.com/67c0e258b1834fe31165bc89?width=1200&format=jpeg",
+            "publishedAt": "2025-03-12T09:35:01Z",
+            "content": "At xAI, Elon Musk has marshaled a workforce that has ballooned by more than 1,000 employees in less than two years as he goes head-to-head with rivals OpenAI and Google.\r\nBusiness Insider reviewed th… [+5851 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Slashdot.org"
+            },
+            "author": "EditorDavid",
+            "title": "Tesla Moves Towards Launching an Uber Competitor",
+            "description": "\"Tesla is taking steps to launch a ride-sharing service that could compete directly with Uber, Lyft and Waymo,\" reports Axios, noting that Tesla \"has filed for a transportation charter-party carrier permit from the California Public Utilities Commission, Bloo…",
+            "url": "https://tech.slashdot.org/story/25/03/01/0346205/tesla-moves-towards-launching-an-uber-competitor",
+            "urlToImage": "https://a.fsdn.com/sd/topics/transportation_64.png",
+            "publishedAt": "2025-03-01T16:34:00Z",
+            "content": "Shouldn't that no talent assclown stick to being an unelected con man? Isn't there more taxpayer money he can leech off of?\r\nWhat - you don't think he'll be getting stoopid amounts of government fina… [+439 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Lucas Ropek",
+            "title": "Canadian Officials Cancel $100 Million Starlink Contract, Propose 100% Tariffs on Teslas",
+            "description": "Musk is in the firing line for Trump's pointless economic war on America's allies.",
+            "url": "https://gizmodo.com/canadian-officials-cancel-100-million-starlink-contract-propose-100-tariffs-on-teslas-2000571699",
+            "urlToImage": "https://gizmodo.com/app/uploads/2024/10/MuskLeaping.jpg",
+            "publishedAt": "2025-03-05T14:35:23Z",
+            "content": "President Donald Trump has unleashed economic warfare on two of America’s most closely aligned trading partners (and political allies): Mexico and Canada. On Tuesday, the Trump administration put int… [+2920 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "CNET"
+            },
+            "author": "Antuan Goodwin",
+            "title": "Ford Tested Its Gen 2 NACS Adapter by Running It Over With an F-150",
+            "description": "Ford EV owners can now find Tesla Superchargers via Apple Maps, and they can charge more easily and reliably.",
+            "url": "https://www.cnet.com/home/electric-vehicles/ford-tested-its-gen-2-nacs-adapter-by-running-it-over-with-an-f-150/",
+            "urlToImage": "https://www.cnet.com/a/img/resize/47b801eff0cc1866181e267e6092ba70099bf2bb/hub/2025/03/11/702155f4-deb1-4e0a-a3cc-4f0ed636c0cc/ford-charging-adapter-testing-02.jpg?auto=webp&fit=crop&height=675&width=1200",
+            "publishedAt": "2025-03-11T12:00:10Z",
+            "content": "It's been a year since Ford's EVs unlocked third-party access to Tesla's Supercharger network using complimentary NACS Fast Charging Adapters. This week, the automaker doubled down on its commitment … [+3011 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "aaltchek@insider.com (Ana Altchek)",
+            "title": "6 falling Tesla sales numbers that should worry Elon Musk",
+            "description": "Elon Musk told investors to expect Tesla sales to grow this year. Plummeting sales in multiple countries complicates that goal.",
+            "url": "https://www.businessinsider.com/tesla-falling-sales-numbers-should-worry-elon-musk-2025-3",
+            "urlToImage": "https://i.insider.com/67c8610269253ccddf985103?width=1200&format=jpeg",
+            "publishedAt": "2025-03-05T20:05:53Z",
+            "content": "Elon Musk told investors to expect Tesla sales to grow this year but plummeting sales in multiple countries around the world are complicating that goal.\r\nWhile Tesla's Model Y continues to be a top s… [+2634 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Matt Novak",
+            "title": "Elon Musk Claims X Outage From ‘Massive Cyberattack’ Without Providing Evidence",
+            "description": "The billionaire sees conspiracies everywhere these days.",
+            "url": "https://gizmodo.com/elon-musk-claims-x-outage-from-massive-cyberattack-without-providing-evidence-2000573986",
+            "urlToImage": "https://gizmodo.com/app/uploads/2025/03/elon-musk-frown-face-GettyImages-2203703329-copy.jpg",
+            "publishedAt": "2025-03-10T18:48:10Z",
+            "content": "X, the social media platform formerly known as Twitter, has been suffering from outages all day Monday. And owner Elon Musk has finally said what’s behind it. Well, what he thinks is behind it. The b… [+4188 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "CNET"
+            },
+            "author": "Omar Gallaga",
+            "title": "China's BYD Claims 5-Minute EV Battery Charge Gives 250 Miles of Range",
+            "description": "An apparent battery breakthrough could be good news for the EV industry from a Chinese company that previously pledged to work with Tesla.",
+            "url": "https://www.cnet.com/home/electric-vehicles/chinas-byd-claims-5-minute-ev-battery-charging-gives-250-miles-of-range/",
+            "urlToImage": "https://www.cnet.com/a/img/resize/f183835b97e257af64efb187474d782c5614fac4/hub/2025/03/18/448efd44-d3c0-426b-aad7-314fca5b446f/gettyimages-2153819146.jpg?auto=webp&fit=crop&height=675&width=1200",
+            "publishedAt": "2025-03-18T15:03:00Z",
+            "content": "Chinese auto manufacturer BYD says it has developed technology that speeds up electric vehicle battery charging to as little as five minutes at 1,000 kilowatts, providing enough energy for nearly 250… [+684 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Lloyd Lee,Katherine Tangalakis-Lippert",
+            "title": "Vandalize a Tesla dealership? Trump says he'll label that domestic terrorism.",
+            "description": "President Donald Trump responded to a question about Tesla dealership attacks, saying they should be considered domestic terrorism.",
+            "url": "https://www.businessinsider.com/trump-tesla-vandalism-domestic-terrorism-elon-musk-2025-3",
+            "urlToImage": "https://i.insider.com/67d097c8b8b41a9673fa535f?width=1200&format=jpeg",
+            "publishedAt": "2025-03-11T20:25:03Z",
+            "content": "Tesla dealerships around the country have been vandalized.Smith Collection/Gado/Getty Images\r\nPresident Donald Trump says he will label attacks against Tesla dealerships domestic terrorism in respons… [+540 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "sjackson@insider.com (Sarah Jackson)",
+            "title": "Sen. Mark Kelly is looking into selling his Tesla over Elon Musk. Other big names have already pulled the trigger.",
+            "description": "\"It's kind of cheaply built on the inside, but I love the performance,\" the Arizona Senator told reporters this week about his Tesla.",
+            "url": "https://www.businessinsider.com/celebrities-politicians-who-sold-tesla-over-elon-musk-trump",
+            "urlToImage": "https://i.insider.com/67d1c696b8b41a9673fa6cb8?width=1200&format=jpeg",
+            "publishedAt": "2025-03-12T17:39:50Z",
+            "content": "Sen. Mark Kelly might become the latest big name to get rid of his Tesla over Elon Musk's politics.\r\nThe Arizona Democrat told reporters on Tuesday that he's \"looking into\" selling his Tesla, though … [+424 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Jack Newsham,Alice Tecotzky,Juliana Kaplan",
+            "title": "A veteran Tesla engineering manager has joined DOGE, and he's set to attend a NASA layoffs meeting",
+            "description": "Alexander Simonpour is at least the fourth Tesla employee to be connected with the White House's headcount-slashing initiative.",
+            "url": "https://www.businessinsider.com/tesla-employee-alexander-simonpour-nasa-doge-team-2025-3",
+            "urlToImage": "https://i.insider.com/67d490fc585f1dff88b24086?width=1200&format=jpeg",
+            "publishedAt": "2025-03-14T21:04:25Z",
+            "content": "President Donald Trump and Elon Musk, the de facto leader of DOGE, have been hitting some legal obstacles regarding their government efficiency efforts.Brandon Bell/Pool via AP\r\n<ul><li>Alexander Sim… [+2508 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Erica Star Domena,Rachel Cohn",
+            "title": "Tesla shareholders fear Elon Musk's focus on DOGE is tanking stock prices",
+            "description": "Tesla shareholders are frustrated with Elon Musk as he focuses more on DOGE and Tesla's stock price crashes.",
+            "url": "https://www.businessinsider.com/tesla-shareholders-fear-elon-musks-focus-on-doge-tanking-stock-2025-3",
+            "urlToImage": "https://i.insider.com/67d092e6b8b41a9673fa520e?width=1200&format=jpeg",
+            "publishedAt": "2025-03-11T20:04:53Z",
+            "content": "Tesla shareholders are frustrated with Elon Musk as he focuses more on DOGE and Tesla's stock price crashes.Read the original article on Business Insider"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "aaltchek@insider.com (Ana Altchek)",
+            "title": "Ron Baron's firm sold some Tesla shares — but he plans to keep his",
+            "description": "Investor Ron Baron said his firm trimmed its Tesla stake because he has to \"deal with the critiques of my clientele for how large the positions are.\"",
+            "url": "https://www.businessinsider.com/baron-capital-sells-some-tesla-stock-shares-2025-3",
+            "urlToImage": "https://i.insider.com/67d048f8585f1dff88b1c18f?width=1200&format=jpeg",
+            "publishedAt": "2025-03-11T17:13:15Z",
+            "content": "Ron Baron said his asset management firm Baron Capital sold Tesla shares last month after concerns that its position was becoming too large.\r\n\"Everyone, you know, has to deal with certain clientele,\"… [+2643 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Tom Carter",
+            "title": "Tesla sales are slumping in the US, too",
+            "description": "New Tesla registrations in the US fell 11% in January from a year earlier, per data from S&P Global — even as the company's EV rivals surged.",
+            "url": "https://www.businessinsider.com/us-latest-place-tesla-sales-plunging-elon-musk-2025-3",
+            "urlToImage": "https://i.insider.com/67d2bb43b8b41a9673fa811b?width=1200&format=jpeg",
+            "publishedAt": "2025-03-14T10:24:11Z",
+            "content": "Tesla CEO Elon Musk has faced a backlash over his work at DOGE.ODD ANDERSEN/Getty Images\r\n<ul><li>Tesla sales are slumping across the globe, including in the US.</li><li>According to industry data, n… [+2131 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Sophie Kleeman",
+            "title": "Donald Trump reviews Tesla Model S: 'Everything's computer'",
+            "description": "At the White House on Tuesday, Donald Trump and Elon Musk flitted about among a fleet of Teslas. \"Everything's computer,\" Trump marveled.",
+            "url": "https://www.businessinsider.com/donald-trump-tesla-model-s-review-everythings-computer-2025-3",
+            "urlToImage": "https://i.insider.com/67d0a42669253ccddf98efb7?width=1200&format=jpeg",
+            "publishedAt": "2025-03-11T21:24:35Z",
+            "content": "Andrew Harnik/Getty Images\r\n<ul><li>Elon Musk visited Donald Trump at the White House on Tuesday with a fleet of Tesla vehicles.</li><li>Upon entering the driver's side of a cherry red Model S, Donal… [+2063 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Lauren Edmonds",
+            "title": "Kim Kardashian posts photo shoot with a Tesla Cybertruck and Optimus robot",
+            "description": "One photo showed Kim Kardashian posing in the bed of a Cybertruck, while another featured her cuddling with an Optimus robot near the beach.",
+            "url": "https://www.businessinsider.com/kim-kardashian-tesla-cybertruck-optimus-robot-2025-3",
+            "urlToImage": "https://i.insider.com/67d5efd2b8b41a9673faca13?width=1200&format=jpeg",
+            "publishedAt": "2025-03-15T22:39:43Z",
+            "content": "Kim Kardashian posed with Tesla products in a magazine photo shoot published this month.Axelle/Bauer-Griffin/FilmMagic\r\n<ul><li>Kim Kardashian posted photos of a Tesla Cybertruck and robot to Instagr… [+2512 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Jack Newsham",
+            "title": "Read the letter Tesla wrote warning the Trump administration about harm from a trade war",
+            "description": "Tesla said Trump's tariffs could increase costs to manufacture and lead other countries to counter with tariffs on cars and parts.",
+            "url": "https://www.businessinsider.com/tesla-trump-trade-war-costly-tariffs-2025-3",
+            "urlToImage": "https://i.insider.com/67d361e769253ccddf993a72?width=1024&format=jpeg",
+            "publishedAt": "2025-03-13T23:15:53Z",
+            "content": "President Donald Trump and Tesla CEO Elon Musk, along with his son X Æ A-Xii, speaks to reporters by a Tesla vehicle on the South Lawn of the White House.Pool via AP\r\n<ul><li>The Trump administration… [+2641 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Morgan McFall-Johnsen",
+            "title": "Elon Musk just scored a much-needed win: SpaceX brought those 2 stranded astronauts home",
+            "description": "Tesla and SpaceX have had a rough couple of months, but the highly anticipated return flight of two NASA astronauts is a boost for Elon Musk.",
+            "url": "https://www.businessinsider.com/elon-musk-win-spacex-returns-nasa-astronauts-2025-3",
+            "urlToImage": "https://i.insider.com/67d9bf3669253ccddf999a0a?width=1200&format=jpeg",
+            "publishedAt": "2025-03-18T22:01:57Z",
+            "content": "Finally, Elon Musk has a black-and-white victory this year.Saul Loeb/AFP via Getty Images\r\n<ul><li>SpaceX just brought home two astronauts who were stuck on the International Space Station for months… [+4596 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Kimberly Witt",
+            "title": "We're getting rid of our Tesla — and Elon Musk's politics have nothing to do with it",
+            "description": "After tons of research we bought a Tesla Model Y. We didn't realize how expensive it'd be to insure it. Now we want to sell it.",
+            "url": "https://www.businessinsider.com/we-are-selling-our-tesla-model-y-2025-3",
+            "urlToImage": "https://i.insider.com/67cb4b5e69253ccddf98a41a?width=1200&format=jpeg",
+            "publishedAt": "2025-03-10T12:46:01Z",
+            "content": "Tesla Hong Kong\r\n<ul><li>I'm not a car person and could drive whatever, but my husband loves cars.</li><li>After doing tons of research, he decided we needed a Tesla Model Y.</li><li>Insuring it is v… [+4421 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Dominick Reuter,Alice Tecotzky",
+            "title": "Angel investor says she's ditching her Teslas over Elon Musk — and might let people smash one with sledgehammers",
+            "description": "\"I'm just one voice, but one voice can turn into many,\" investor Joanne Wilson told Business Insider about her decision to sell her Tesla.",
+            "url": "https://www.businessinsider.com/angel-investor-sold-tesla-elon-musk-2025-3",
+            "urlToImage": "https://i.insider.com/67cf1a42b8b41a9673fa2bbf?width=1200&format=jpeg",
+            "publishedAt": "2025-03-10T17:51:49Z",
+            "content": "Getty Images\r\n<ul><li>Joanne Wilson says she's among the cohort of Americans ditching their Teslas in protest of Elon Musk.</li><li>The angel investor and her husband, VC Fred Wilson, owned a pair of… [+2579 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Grace Eliza Goodwin,Benjamin Zhang",
+            "title": "President Trump wants to buy a Tesla. We have some advice for him on which to choose.",
+            "description": "Which Tesla is best for POTUS? Donald trump may want the fastest model on the market, the most expensive, or the most controversial.",
+            "url": "https://www.businessinsider.com/what-tesla-trump-should-buy-depending-what-he-wants-2025-3",
+            "urlToImage": "https://i.insider.com/67d072b469253ccddf98e5d5?width=1200&format=jpeg",
+            "publishedAt": "2025-03-11T19:17:21Z",
+            "content": "A Cybertruck sits parked on the South Portico of the White House next to other Tesla vehicles.Mandel NGAN / AFP\r\n<ul><li>Donald Trump says he wants to buy a Tesla to support Elon Musk.</li><li>Tesla … [+5778 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Lloyd Lee",
+            "title": "Tesla's latest decline could be one for the history books, JPMorgan analysts say",
+            "description": "Tesla recently lost nearly 50% of its $1.5 trillion market. JPMorgan analysts don't know another car company that lost so much value so quickly.",
+            "url": "https://www.businessinsider.com/tesla-stock-decline-jp-morgan-analyst-guidance-2025-3",
+            "urlToImage": "https://i.insider.com/67d2202bb8b41a9673fa7cc3?width=1200&format=jpeg",
+            "publishedAt": "2025-03-13T02:38:24Z",
+            "content": "Elon Musk's involvement with the Trump administration has some analysts concerned that the CEO isn't spending enough time running his companies.Apu Gomes/Getty Images\r\n<ul><li>About 48% of Tesla's ma… [+3922 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Kwan Wei Kevin Tan",
+            "title": "Elon Musk said Tesla used internet videos to train self-driving tech in China",
+            "description": "Tesla rolled out self-driving features to some of its cars in China after BYD said all its cars would get its self-driving tech for free.",
+            "url": "https://www.businessinsider.com/elon-musk-tesla-internet-videos-train-china-self-driving-tech-2025-2",
+            "urlToImage": "https://i.insider.com/67be88ccb8b41a9673f8fbdb?width=1200&format=jpeg",
+            "publishedAt": "2025-02-26T05:56:58Z",
+            "content": "Tesla rolled out self-driving features to some of its cars in China on Tuesday.Hector Retamal/AFP via Getty Images\r\n<ul><li>Tesla introduced self-driving features to some of its vehicles in China on … [+2198 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Ana Altchek",
+            "title": "Cybertruck owners tell us what it's like driving the most controversial vehicle in the world",
+            "description": "Cybertruck owners tell BI they have faced backlash amid the 'Tesla Takedown' protests, from being yelled at to being shot at with paintballs.",
+            "url": "https://www.businessinsider.com/cybertruck-owners-tesla-takedown-protest-harassment-vandalism-2025-3",
+            "urlToImage": "https://i.insider.com/67d34b00585f1dff88b21d05?width=1200&format=jpeg",
+            "publishedAt": "2025-03-14T08:30:01Z",
+            "content": "Cybertruck owner Tommy Huynh told BI that his vehicle (pictured right) was shot with a paintball gun in early January.Getty Images/Steven Minnick\r\n<ul><li>Cybertruck owners told BI about their experi… [+7103 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Thibault Spirlet",
+            "title": "Tesla rolls out self-driving tech in China after BYD offers it for free",
+            "description": "Elon Musk's Tesla is under pressure in the world's largest car market from rivals including BYD that are fast expanding outside China.",
+            "url": "https://www.businessinsider.com/tesla-china-self-driving-features-byd-offers-free-ev-2025-2",
+            "urlToImage": "https://i.insider.com/67bdbe384e7cbbbe3dc46bc9?width=1200&format=jpeg",
+            "publishedAt": "2025-02-25T13:00:34Z",
+            "content": "Tesla owners in China can use driver-assist features on urban roads.CFOTO/Future Publishing via Getty Images\r\n<ul><li>Tesla is rolling out self-driving features to some cars in China, per a software … [+2210 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Kelsey Vlamis",
+            "title": "Elon Musk said he's running his businesses with 'great difficulty' as Tesla stock falls 15%",
+            "description": "Elon Musk said in an interview that running his businesses while working with the White House has not been easy. Tesla stock declined 15% on Monday.",
+            "url": "https://www.businessinsider.com/elon-musk-running-companies-great-difficulty-doge-2025-3",
+            "urlToImage": "https://i.insider.com/67cf55b5585f1dff88b1b612?width=1200&format=jpeg",
+            "publishedAt": "2025-03-10T21:25:51Z",
+            "content": "Elon Musk said it hasn't been easy to run his businesses while working closely with the White House on government efficiency efforts.Saul Loeb/AFP/Getty Images\r\n<ul><li>Elon Musk said running his bus… [+1058 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Lauren Steussy,Lloyd Lee",
+            "title": "A photographer took a shot of Trump's notes — and they read like a Tesla sales pitch",
+            "description": "President Donald Trump checked out Teslas at a White House event Tuesday with Elon Musk. He carried a note with jotted down Tesla prices.",
+            "url": "https://www.businessinsider.com/photo-trumps-notes-shows-tesla-prices-2025-3",
+            "urlToImage": "https://i.insider.com/67d0a720585f1dff88b1d496?width=1200&format=jpeg",
+            "publishedAt": "2025-03-11T23:32:14Z",
+            "content": "President Donald Trump holding a handwritten list of Tesla options.Andrew Harnik/Getty Images\r\n<ul><li>President Donald Trump said he plans to buy a Tesla to support Elon Musk.</li><li>Trump praised … [+2607 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Charissa Cheong",
+            "title": "I bought a Tesla for its safety and technology. Strangers have mocked me for supporting Elon Musk, but that won't stop me from buying another one.",
+            "description": "Mitchell Feldman bought his Tesla in 2022 and loved the car's safety features and high tech system. He didn't realize it would come with scrutiny.",
+            "url": "https://www.businessinsider.com/tesla-owner-confronted-about-musk-shocked-2025-3",
+            "urlToImage": "https://i.insider.com/67d472af585f1dff88b2378b?width=1200&format=jpeg",
+            "publishedAt": "2025-03-16T09:20:01Z",
+            "content": "Mitchell Feldman said he bought his Tesla in 2022 the experience, safety, and technology.Mitchell Feldman\r\n<ul><li>Mitchell Feldman bought his Tesla Model Y in 2022 and was immediately enamoured by t… [+3957 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Grace Kay",
+            "title": "Tesla more than tripled the workers testing its self-driving technology in California",
+            "description": "The increase in capability comes as Elon Musk's electric-vehicle maker aims to release its much-hyped Robotaxi in some cities by the end of 2025.",
+            "url": "https://www.businessinsider.com/tesla-autonomous-driving-california-robotaxi-2025-3",
+            "urlToImage": "https://i.insider.com/66b0fbcfb4912df3ae18ec38?width=1200&format=jpeg",
+            "publishedAt": "2025-03-14T08:47:02Z",
+            "content": "Tesla registered over 220 test drivers and 100 vehicles for an autonomous driving permit in California.Justin Sullivan/Getty Images\r\n<ul><li>Tesla registered over 220 test drivers and 100 vehicles fo… [+4877 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": "Stephen Proctor",
+            "title": "Leaked report reveals shocking downfall for Tesla — here's what's driving the drop in sales",
+            "description": "\"Tesla sales have been declining worldwide, especially in Europe.\"",
+            "url": "https://autos.yahoo.com/leaked-report-reveals-shocking-downfall-110051133.html",
+            "urlToImage": "https://s.yimg.com/ny/api/res/1.2/K2P9O2aB4JUzIKqJ8M0YJQ--/YXBwaWQ9aGlnaGxhbmRlcjt3PTEyMDA7aD04MDA-/https://media.zenfs.com/en/the_cool_down_737/27225c14ccfbc8dc58dbb15af45f1c4e",
+            "publishedAt": "2025-03-18T11:00:51Z",
+            "content": "Tesla shareholders recently got some bad news. According to Electrek, the electric vehicle giant is expected to ship the fewest number of vehicles in the first quarter of 2025 since Q3 of 2022.\r\nWhat… [+4435 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Tom Carter",
+            "title": "Tesla is offering free lifetime supercharging for Cybertruck buyers as demand slows",
+            "description": "Sales of the electric truck, which had a torturous production ramp and launched at a higher price tag than expected, have been underwhelming.",
+            "url": "https://www.businessinsider.com/tesla-offers-free-supercharging-for-cybertruck-buyers-as-demand-slows-2025-3",
+            "urlToImage": "https://i.insider.com/67c6daa169253ccddf982eb1?width=1200&format=jpeg",
+            "publishedAt": "2025-03-04T11:57:16Z",
+            "content": "Tesla CEO Elon Musk unveils the Cybertruck at an event in 2019.FREDERIC J. BROWN/AFP via Getty Images\r\n<ul><li>Tesla is offering some Cybertruck buyers free supercharging as it grapples with stagnant… [+2782 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "MacRumors"
+            },
+            "author": "Juli Clover",
+            "title": "Apple Maps EV Routing for Ford Vehicles Now Supports Tesla Chargers",
+            "description": "Ford Mustang Mach-E and Ford F-150 Lightning customers that use the Apple Maps EV Routing feature in CarPlay can now be automatically routed to EV chargers that use the North American Charging Standard (NACS), Ford announced today.\n\n\n\n\n\nNACS chargers include …",
+            "url": "https://www.macrumors.com/2025/03/10/ford-apple-maps-ev-routing-nacs/",
+            "urlToImage": "https://images.macrumors.com/t/kxFzpHSfCZum7oW8OdWnMK4z6I0=/2000x/article-new/2025/03/ford-nacs-ev-routing.jpg",
+            "publishedAt": "2025-03-10T21:20:53Z",
+            "content": "Ford Mustang Mach-E and Ford F-150 Lightning customers that use the Apple Maps EV Routing feature in CarPlay can now be automatically routed to EV chargers that use the North American Charging Standa… [+1364 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Brent D. Griffiths,Bryan Metzger",
+            "title": "Ex-astronaut Mark Kelly debuted his Chevy SUV after dumping Tesla",
+            "description": "Sen. Mark Kelly of Arizona said he could no longer stand the association with Elon Musk.",
+            "url": "https://www.businessinsider.com/mark-kelly-sold-tesla-elon-musk-doge-backlash-chevy-2025-3",
+            "urlToImage": "https://i.insider.com/67d47203b8b41a9673fab8fa?width=1200&format=jpeg",
+            "publishedAt": "2025-03-14T20:07:00Z",
+            "content": "Arizona Sen. Mark Kelly's relationship with Elon Musk has rapidly deteriorated as the billionaire targets the Democrat on social media.Kevin Dietsch/Getty Images\r\n<ul><li>Sen. Mark Kelly sold his Tes… [+2361 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": null,
+            "title": "Marjorie Taylor Greene Wants Tesla Protests Investigated, Presumably Because They're Hurting The Value Of Her Tesla Stock",
+            "description": null,
+            "url": "https://consent.yahoo.com/v2/collectConsent?sessionId=1_cc-session_047f1e09-477d-4813-93a6-36794d69b3f0",
+            "urlToImage": null,
+            "publishedAt": "2025-03-13T22:06:00Z",
+            "content": "If you click 'Accept all', we and our partners, including 238 who are part of the IAB Transparency &amp; Consent Framework, will also store and/or access information on a device (in other words, use … [+702 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Grace Kay",
+            "title": "Tesla's stock slump is driving Wall Street crazy — but not Elon Musk's employees",
+            "description": "Wall Street is sounding the alarm over Tesla's stock slump. The sentiment among employees? Shrug.",
+            "url": "https://www.businessinsider.com/tesla-stock-price-drop-employees-react-2025-3",
+            "urlToImage": "https://i.insider.com/67d9a13eb8b41a9673fafa66?width=1200&format=jpeg",
+            "publishedAt": "2025-03-18T20:11:32Z",
+            "content": "Getty Images; Emojipedia; Rebecca Zisser/BI\r\n<ul><li>Tesla's stock is down 44% year-to-date amid sales woes and CEO Elon Musk's involvement in DOGE.</li><li>Inside Tesla, however, workers say they're… [+4104 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Hipertextual"
+            },
+            "author": "Alberto Martín",
+            "title": "Las ventas de Tesla en Europa se desploman",
+            "description": "Las ventas de Tesla en el viejo continente, con la suma de Europa continental y las Islas Británicas, han caído drásticamente en el mes de enero, última fecha de las que se tienen datos de ventas de la compañía de Elon Musk. Las razones principales, según apu…",
+            "url": "http://hipertextual.com/2025/02/las-ventas-de-tesla-en-europa-se-desploman",
+            "urlToImage": "https://imgs.hipertextual.com/wp-content/uploads/2024/03/elon-musk-molesto.jpg",
+            "publishedAt": "2025-02-25T11:50:04Z",
+            "content": "Las ventas de Tesla en el viejo continente, con la suma de Europa continental y las Islas Británicas, han caído drásticamente en el mes de enero, última fecha de las que se tienen datos de ventas de … [+1958 chars]"
+        },
+        {
+            "source": {
+                "id": "the-next-web",
+                "name": "The Next Web"
+            },
+            "author": "Siôn Geschwindt",
+            "title": "Ex-Tesla, Polestar execs unveil new ultralight electric sports cars",
+            "description": "With their heavy battery packs, EVs are hardly known for being lightweight. That is, perhaps, until now.  British startup Longbow — founded by former Tesla, Lucid, and Polestar execs — emerged from stealth today with plans for two new ultralight EVs. The comp…",
+            "url": "https://thenextweb.com/news/ex-tesla-polestar-execs-unveil-ultralight-ev-sports-cars",
+            "urlToImage": "https://img-cdn.tnwcdn.com/image/tnw-blurple?filter_last=1&fit=1280%2C640&url=https%3A%2F%2Fcdn0.tnwcdn.com%2Fwp-content%2Fblogs.dir%2F1%2Ffiles%2F2025%2F03%2FUntitled-design-35.jpg&signature=097683db9404330edb944d683e439444",
+            "publishedAt": "2025-03-12T15:48:04Z",
+            "content": "With their heavy battery packs, EVs are hardly known for being lightweight. That is, perhaps, until now. \r\nBritish startup Longbow founded by former Tesla, Lucid, and Polestar execs emerged from stea… [+4600 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "NPR"
+            },
+            "author": "Bobby Allyn",
+            "title": "A new document undercuts Trump admin's denials about $400 million Tesla deal",
+            "description": "The State Department claimed a plan to buy thousands of armored Teslas was left over from the Biden administration. A document obtained by NPR shows the Biden plan was far smaller.",
+            "url": "https://www.npr.org/2025/02/24/nx-s1-5305269/tesla-state-department-elon-musk-trump",
+            "urlToImage": "https://npr.brightspotcdn.com/dims3/default/strip/false/crop/5892x3314+0+219/resize/1400/quality/100/format/jpeg/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F14%2F84%2Fdedf745d4983bed66821e89667d3%2Fgettyimages-2190848839.jpg",
+            "publishedAt": "2025-02-24T17:22:56Z",
+            "content": "The controversy started in a very Washington way: as a line item in a government spreadsheet buried on the State Department's website.\r\nIt appeared as if the State Department was taking steps to awar… [+9301 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Stealmytesla.com"
+            },
+            "author": "John Gruber",
+            "title": "Steal My Tesla",
+            "description": null,
+            "url": "http://stealmytesla.com/",
+            "urlToImage": null,
+            "publishedAt": "2025-03-11T18:31:21Z",
+            "content": "New service for disgruntled/embarrassed Tesla owners:\n\n\n Our team at Steal My Tesla has years of experience in the\nautomotive industry, with a special focus on luxury vehicles,\npremium wheels and rim… [+141 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Kelsey Vlamis",
+            "title": "Elon Musk's net worth dropped $29 billion in one day as Tesla stock tanks",
+            "description": "Elon Musk's net worth fell by $29 billion on Monday. Tesla's stock free fall has some investors concerned about the CEO's focus.",
+            "url": "https://www.businessinsider.com/elon-musk-net-worth-drops-billion-tesla-stock-2025-3",
+            "urlToImage": "https://i.insider.com/67cf6f90585f1dff88b1b7d5?width=1200&format=jpeg",
+            "publishedAt": "2025-03-10T23:29:55Z",
+            "content": "Elon Musk's net worth has dropped by $132 billion this year as Tesla's stock price has tanked.Andrew Harnik/Getty Images\r\n<ul><li>Elon Musk's net worth fell by $29 billion as Monday as Tesla's stock … [+2222 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Tom Carter",
+            "title": "BYD says it can charge an EV in 5 minutes. That's yet another challenge for Tesla.",
+            "description": "BYD's superchargers are four times as powerful as Tesla's current chargers, which Elon Musk's firm says can add 200 miles of range in 15 minutes.",
+            "url": "https://www.businessinsider.com/byd-unveils-fast-chargers-400km-range-5-minutes-tesla-challenge-2025-3",
+            "urlToImage": "https://i.insider.com/67d94f91585f1dff88b26afc?width=1200&format=jpeg",
+            "publishedAt": "2025-03-18T11:36:32Z",
+            "content": "BYD chairman and founder Wang Chuanfu said the company wanted to \"solve user's charging anxiety\" with the new technology.VCG/VCG via Getty Images\r\n<ul><li>BYD has snatched the lead in the race to bui… [+2929 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "Effie Webb",
+            "title": "Reid Hoffman denies having 'beef' with Elon Musk: 'It's his beef with me!'",
+            "description": "Reid Hoffman says Elon Musk's feud with him is one-sided, accusing Musk of resenting OpenAI's success.",
+            "url": "https://www.businessinsider.com/reid-hoffman-denies-beef-elon-musk-rivalry-linkedin-tesla-2025-3",
+            "urlToImage": "https://i.insider.com/67d2aae269253ccddf991980?width=1200&format=jpeg",
+            "publishedAt": "2025-03-13T10:19:11Z",
+            "content": "Elon Musk and Reid Hoffman traded jabs about OpenAI and Tesla.Getty Images\r\n<ul><li>Reid Hoffman said Thursday that a feud with Elon Musk is one-sided.</li><li>Musk has accused Hoffman of funding Tes… [+2970 chars]"
+        },
+        {
+            "source": {
+                "id": "wired",
+                "name": "Wired"
+            },
+            "author": "Martin Cizmar",
+            "title": "Comfort Colors T-Shirts Are the Only Thing I’ll Wear",
+            "description": "I happened upon the budget brand at a chintzy souvenir shop in Maine. I've since sworn full allegiance to the cult of Comfort Colors.",
+            "url": "https://www.wired.com/story/comfort-colors-t-shirts-are-the-best/",
+            "urlToImage": "https://media.wired.com/photos/67ca2747f792a8fe36e66a96/191:100/w_1280,c_limit/Comfort-Colors-T-Shirts-Reviewer-Collage-032025-SOURCE-Martin-Cizmar.jpg",
+            "publishedAt": "2025-03-08T13:33:00Z",
+            "content": "I tend to buy T-shirts in bunches. Anytime I find a shirt I really like, I acquire at least a week's worth. In the era retroactively known as indie sleaze, I was outfitted exclusively in American App… [+2366 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": null,
+            "title": "Musk Melts Down as Tesla Stock Price Plunges",
+            "description": null,
+            "url": "https://consent.yahoo.com/v2/collectConsent?sessionId=1_cc-session_a42ceb12-76ff-4d1a-8fd5-8e85f7d1a6c1",
+            "urlToImage": null,
+            "publishedAt": "2025-03-10T21:25:04Z",
+            "content": "If you click 'Accept all', we and our partners, including 238 who are part of the IAB Transparency &amp; Consent Framework, will also store and/or access information on a device (in other words, use … [+702 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": null,
+            "title": "Tesla Reinstated as Top Pick; Analysts Predicts 50% Upide Potential",
+            "description": null,
+            "url": "https://consent.yahoo.com/v2/collectConsent?sessionId=1_cc-session_e8f9049d-bbb8-447c-9f24-1bd7ff9076f8",
+            "urlToImage": null,
+            "publishedAt": "2025-03-03T13:00:40Z",
+            "content": "If you click 'Accept all', we and our partners, including 238 who are part of the IAB Transparency &amp; Consent Framework, will also store and/or access information on a device (in other words, use … [+702 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": null,
+            "title": "Musk launches appeal to restore $56 billion Tesla payday",
+            "description": null,
+            "url": "https://consent.yahoo.com/v2/collectConsent?sessionId=1_cc-session_d6adf866-579c-405c-b727-899e51054cb6",
+            "urlToImage": null,
+            "publishedAt": "2025-03-11T22:30:29Z",
+            "content": "If you click 'Accept all', we and our partners, including 238 who are part of the IAB Transparency &amp; Consent Framework, will also store and/or access information on a device (in other words, use … [+702 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": "editorial-team@simplywallst.com (Simply Wall St)",
+            "title": "Tesla (NasdaqGS:TSLA) Climbs 13% On Rumors Of Potential Deal With Nissan",
+            "description": "Tesla (NasdaqGS:TSLA) recently experienced a 12.5% increase in its share price over the past week, a move potentially influenced by rumors of Tesla's...",
+            "url": "https://finance.yahoo.com/news/tesla-nasdaqgs-tsla-climbs-13-172906614.html",
+            "urlToImage": "https://media.zenfs.com/en/simply_wall_st__316/8a9a68e8370d8514f2f282dc3b4a5a72",
+            "publishedAt": "2025-03-17T17:29:06Z",
+            "content": "Tesla recently experienced a 12.5% increase in its share price over the past week, a move potentially influenced by rumors of Tesla's proposed strategic investment in Nissan Motor Co. This follows re… [+2908 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Detroit Free Press"
+            },
+            "author": "Eric D. Lawrence, Detroit Free Press",
+            "title": "I rented a Tesla in metro Detroit: Reactions I got driving Elon Musk's controversial brand",
+            "description": "During trips around parts of the metro area, the rented Tesla appeared to draw little notice aside from one possible minor incident.",
+            "url": "https://www.freep.com/story/money/cars/2025/03/15/tesla-elon-musk-donald-trump/82408154007/",
+            "urlToImage": "https://s.yimg.com/ny/api/res/1.2/8HoNwS8EqH6AtfneSMWSUw--/YXBwaWQ9aGlnaGxhbmRlcjt3PTEyMDA7aD0xMDA5/https://media.zenfs.com/en/detroit_free_press_natl_articles_245/29357176aab18143c132f4fc5fe33e49",
+            "publishedAt": "2025-03-15T13:14:40Z",
+            "content": "With so much attention on the Tesla brand of late, the Free Press decided to rent a red Tesla for a day this week from a Hertz in Center Line to gauge reaction.\r\nTesla CEO Elon Musks chainsaw-wieldin… [+2956 chars]"
+        },
+        {
+            "source": {
+                "id": "wired",
+                "name": "Wired"
+            },
+            "author": "Makena Kelly",
+            "title": "DOGE Is Putting Major Government Efficiency Projects at Risk",
+            "description": "In its apparent quest to cut government spending and improve efficiency, DOGE has fired entire tech teams devoted to those very things.",
+            "url": "https://www.wired.com/story/doge-major-government-tech-projects-efficiency/",
+            "urlToImage": "https://media.wired.com/photos/67ca184bfec307c84aad3ce6/191:100/w_1280,c_limit/pol_doge_tech_GettyImages-2201505740.jpg",
+            "publishedAt": "2025-03-07T19:14:08Z",
+            "content": "18F was the peoples tech shop, one fired 18F worker tells WIRED. Theres a giant hole left by the closure of 18F. Requests from across the country for help far outpaced 18Fs capacity before the closur… [+3048 chars]"
+        },
+        {
+            "source": {
+                "id": "wired",
+                "name": "Wired"
+            },
+            "author": "Will Knight",
+            "title": "Under Trump, AI Scientists Are Told to Remove ‘Ideological Bias’ From Powerful Models",
+            "description": "A directive from the National Institute of Standards and Technology eliminates mention of “AI safety” and “AI fairness.”",
+            "url": "https://www.wired.com/story/ai-safety-institute-new-directive-america-first/",
+            "urlToImage": "https://media.wired.com/photos/67c77508ad19f713de02a563/191:100/w_1280,c_limit/trump-pointing-2202608030.jpg",
+            "publishedAt": "2025-03-14T23:29:46Z",
+            "content": "The National Institute of Standards and Technology (NIST) has issued new instructions to scientists that partner with the US Artificial Intelligence Safety Institute (AISI) that eliminate mention of … [+3395 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Xataka.com"
+            },
+            "author": "Rubén Andrés",
+            "title": "Tesla ha demandado a clientes y periodistas por criticar sus coches en China: lo sorprendente es que está ganando esos juicios",
+            "description": "Los fabricantes de coches de lujo llevan al extremo el cuidado por la reputación de su marca y, por ese motivo, Ferrari o Bugatti pueden meter en listas negras a clientes que no han utilizado sus coches con el respeto debido a lo que representa su marca.\n<!--…",
+            "url": "https://www.xataka.com/movilidad/tesla-ha-demandado-a-clientes-periodistas-criticar-sus-coches-china-sorprendente-que-esta-ganando-esos-juicios",
+            "urlToImage": "https://i.blogs.es/33c1e2/tesla-china/840_560.jpeg",
+            "publishedAt": "2025-02-24T19:15:56Z",
+            "content": "Los fabricantes de coches de lujo llevan al extremo el cuidado por la reputación de su marca y, por ese motivo, Ferrari o Bugatti pueden meter en listas negras a clientes que no han utilizado sus coc… [+4616 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "jzinkula@insider.com (Jacob Zinkula)",
+            "title": "Uber and Lyft drivers with Teslas don't want to talk about Elon Musk",
+            "description": "Uber and Lyft drivers with Teslas reveal how they handle passenger questions about Elon Musk to preserve tips in a competitive gig economy.",
+            "url": "https://www.businessinsider.com/tesla-elon-musk-uber-lyft-drivers-avoid-talking-politics-passengers-2025-3",
+            "urlToImage": "https://i.insider.com/67c8c7c669253ccddf98689a?width=1200&format=jpeg",
+            "publishedAt": "2025-03-07T09:01:02Z",
+            "content": "Some Uber and Lyft drivers with Teslas don't want to talk with riders about Elon Musk but they'll play along because it's good for business.\r\nWesley Johnson said his passengers regularly mention Musk… [+3809 chars]"
+        },
+        {
+            "source": {
+                "id": "the-verge",
+                "name": "The Verge"
+            },
+            "author": "Andrew J. Hawkins",
+            "title": "Volvo’s ES90 sedan will be built with a Nvidia supercomputer",
+            "description": "Volvo’s next electric vehicle, the ES90 midsized luxury sedan, sounds like its got some serious computing chops. The new EV will come with a dual Nvidia Drive AGX Orin configuration, making it the “most powerful car Volvo ever created in terms of core computi…",
+            "url": "https://www.theverge.com/news/615869/volvo-es90-sedan-nvidia-drive-agx-orin",
+            "urlToImage": "https://platform.theverge.com/wp-content/uploads/sites/2/2025/02/341170_Volvo_ES90_teaser_image.jpg?quality=90&strip=all&crop=0%2C15.095986038394%2C100%2C69.808027923211&w=1200",
+            "publishedAt": "2025-02-19T21:24:22Z",
+            "content": "The ES90 will be based on Volvos Superset tech stack comprising all modules and functionalities that we will use in our future product line-up.\r\nThe ES90 will be based on Volvos Superset tech stack c… [+2654 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "The Atlantic"
+            },
+            "author": "Lora Kelley",
+            "title": "Donald Trump, Tesla Salesman",
+            "description": "In promoting Elon Musk’s car company, Donald Trump showed just how far he’ll go for his allies.",
+            "url": "https://www.theatlantic.com/newsletters/archive/2025/03/donald-trump-tesla-salesman/682024/",
+            "urlToImage": "https://cdn.theatlantic.com/thumbor/yflB3ri7w3KBbRJ6xO2Lkj7jelQ=/0x872:5990x3992/1200x625/media/img/mt/2025/03/GettyImages_2204003116/original.jpg",
+            "publishedAt": "2025-03-12T22:36:00Z",
+            "content": "This is an edition of The Atlantic Daily, a newsletter that guides you through the biggest stories of the day, helps you discover new ideas, and recommends the best in culture. Sign up for it here.In… [+6767 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Lucas Ropek",
+            "title": "Senate Votes to Strip CFPB of Ability to Regulate Platforms Like X",
+            "description": "Conservative activist and friend of Donald Trump, Laura Loomer, is freaking out.",
+            "url": "https://gizmodo.com/senate-votes-to-strip-cfpb-of-ability-to-regulate-platforms-like-x-2000572567",
+            "urlToImage": "https://gizmodo.com/app/uploads/2024/12/elon-musk-dec-5-2024-capitol-hill.jpg",
+            "publishedAt": "2025-03-06T20:30:30Z",
+            "content": "A key federal watchdog is being stripped of its power to oversee potential fraud and abuse in online payment platforms just as Elon Musk’s site, X, attempts to become one.\r\nLate last year, the Consum… [+4301 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Lucas Ropek",
+            "title": "Democrats Expected to Pass a Bill (Drafted by Elon’s Lawyers) That Threatens Your Retirement Fund",
+            "description": "It's not enough to ruin the federal government. Musk doesn't think corporations should have to play by state rules, either.",
+            "url": "https://gizmodo.com/democrats-expected-to-pass-a-bill-drafted-by-elons-lawyers-that-threatens-your-retirement-fund-2000573901",
+            "urlToImage": "https://gizmodo.com/app/uploads/2025/03/Elon-Musk-on-Capitol-Hill.jpg",
+            "publishedAt": "2025-03-10T21:10:16Z",
+            "content": "Due to its highly lenient business laws, the state of Delaware has long been home to a majority of American corporations. However, that leniency is apparently not enough for the world’s richest man, … [+5046 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Thomas Maxwell",
+            "title": "‘Inferior’ Starlink Will Leave Rural Americans Worse Off, Says Ousted Federal Official",
+            "description": "Starlink is cheap to deploy, but could leave rural Americans \"stranded\" with slower speeds and higher costs.",
+            "url": "https://gizmodo.com/inferior-starlink-will-leave-rural-americans-worse-off-says-ousted-federal-official-2000576818",
+            "urlToImage": "https://gizmodo.com/app/uploads/2024/05/8ca125da42e059f4ebb79e41090d2cce.jpg",
+            "publishedAt": "2025-03-17T16:10:27Z",
+            "content": "The head of the Commerce Department’s ambitious plan to expand fiber internet access across rural America warned on Sunday that opening the door to SpaceX’s Starlink would leave rural Americans worse… [+4312 chars]"
+        },
+        {
+            "source": {
+                "id": "business-insider",
+                "name": "Business Insider"
+            },
+            "author": "John L. Dorman",
+            "title": "Delaware is trying to make nice again with corporations after Elon Musk's exit",
+            "description": "Delaware's reputation as a business-friendly state has taken a hit. Musk and other corporate leaders have left Delaware for other states.",
+            "url": "https://www.businessinsider.com/delaware-corporations-elon-musk-tesla-exit-business-climate-2025-3",
+            "urlToImage": "https://i.insider.com/67d5ff6c69253ccddf9963e3?width=1200&format=jpeg",
+            "publishedAt": "2025-03-15T23:02:06Z",
+            "content": "Elon Musk has reincorporated both Tesla and SpaceX outside Delaware.Samuel Corum/Getty Images\r\n<ul><li>Delaware has long been a corporate haven due to its business-friendly laws.</li><li>Elon Musk's … [+3076 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": "Vishesh Raisinghani",
+            "title": "Sacramento woman stuns Ramsey Show co-hosts with story of how she turned $1K into $380K with just 1 stock.",
+            "description": "They say you can't time the stock market, but you can use time to your advantage.",
+            "url": "https://finance.yahoo.com/news/sacramento-woman-stuns-ramsey-show-093000762.html",
+            "urlToImage": "https://media.zenfs.com/en/moneywise_327/cfb4da1b109a973bdd5a1b51f5705e91",
+            "publishedAt": "2025-02-25T09:30:00Z",
+            "content": "This Sacramento woman turned $1,000 into a staggering $380,000 with just 1 stock and left the Ramsey Show stunned. Heres the stock and how you can build investing riches too\r\nWhen you find the right … [+3444 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Fox Business"
+            },
+            "author": "Aislinn Murphy",
+            "title": "Tesla Recalls over 376K Vehicles",
+            "description": "Tesla is recalling over 376,000 of its Model 3 and Model Y electric vehicles in the U.S. in response to concerns they could experience a loss of power steering assistance.",
+            "url": "https://www.foxbusiness.com/lifestyle/tesla-recalls-over-376k-vehicles-over-potential-power-steering-issue",
+            "urlToImage": "https://a57.foxnews.com/static.foxbusiness.com/foxbusiness.com/content/uploads/2025/02/0/0/tesla-model-y.jpg?ve=1&tl=1",
+            "publishedAt": "2025-03-02T11:28:21Z",
+            "content": "Tesla is recalling more than 376,000 of its Model 3 and Model Y electric vehicles in the U.S. over a potential power steering issue.\r\nThe recalled Model 3s and Model Ys could face a loss of power ste… [+3012 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "The Atlantic"
+            },
+            "author": "James Surowiecki",
+            "title": "Tesla Needs a Better Story",
+            "description": "The car company’s fortunes are riding on Elon Musk’s future.",
+            "url": "https://www.theatlantic.com/ideas/archive/2025/03/tesla-stock-elon-musk/682026/",
+            "urlToImage": "https://cdn.theatlantic.com/thumbor/-7mWkpOA_7b4JIChgLp8YonLIZQ=/0x28:1298x704/1200x625/media/img/mt/2025/03/tesla/original.gif",
+            "publishedAt": "2025-03-13T17:38:00Z",
+            "content": "It’s been a bad month for the stock market. But it’s been a terrible month—in fact, a terrible year—for Tesla. Even after rebounding since Monday, perhaps with some help from Donald Trump’s South Law… [+5029 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Hindustan Times"
+            },
+            "author": "Sanya Jain",
+            "title": "Tesla Showroom Set on Fire",
+            "description": "Authorities in France are investigating a suspected arson attack that left a dozen Tesla vehicles burnt at a dealership | Trending",
+            "url": "https://www.hindustantimes.com/trending/tesla-showroom-set-on-fire-12-cars-destroyed-in-suspected-arson-attack-in-france-101741243979863.html",
+            "urlToImage": "https://www.hindustantimes.com/ht-img/img/2025/03/06/1600x900/Tesla_fire_1741244422007_1741244422333.jpg",
+            "publishedAt": "2025-03-10T02:00:53Z",
+            "content": "Authorities in France are investigating a suspected arson attack that left a dozen Tesla vehicles in ruins at a dealership in Plaisance-du-Touch, a suburb of Toulouse. The fire, which broke out late … [+2484 chars]"
+        },
+        {
+            "source": {
+                "id": "abc-news",
+                "name": "ABC News"
+            },
+            "author": "Jon Haworth",
+            "title": "Woman caught trying to plant explosive devices at Tesla dealership",
+            "description": "A woman in Colorado has been arrested after police caught her with explosives at a Tesla dealership, police said.",
+            "url": "https://abcnews.go.com/US/woman-caught-plant-explosive-devices-tesla-dealership/story?id=119244251",
+            "urlToImage": "https://s.abcnews.com/images/US/police-gty-er-210120_1611194059014_hpMain_13_16x9_992.jpg?w=1600",
+            "publishedAt": "2025-02-27T11:08:35Z",
+            "content": "A woman in Colorado has been arrested after police caught her with explosives at a Tesla dealership, police said.\r\nThe 40-year-old suspect, Lucy Grace Nelson, was arrested on Monday after the Lovelan… [+1044 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Gizmodo.com"
+            },
+            "author": "Matt Novak",
+            "title": "Robotaxi Expert Suggests Elon Musk Will Try to ‘Fake’ Cybercabs in June",
+            "description": "Can the Tesla CEO deliver on his promises?",
+            "url": "https://gizmodo.com/robotaxi-expert-suggests-elon-musk-will-try-to-fake-cybercabs-in-june-2000576289",
+            "urlToImage": "https://gizmodo.com/app/uploads/2024/10/robotaxi-mockup-tesla-cybercab.jpg",
+            "publishedAt": "2025-03-14T18:30:41Z",
+            "content": "John Krafcik, the former CEO of the robotaxi company Waymo from 2015-2021, knows a thing or two about the driverless vehicle industry. And when he says that Tesla CEO Elon Musk might use some extreme… [+3877 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Slashdot.org"
+            },
+            "author": "EditorDavid",
+            "title": "Elon Musk Says SpaceX's First Mission to Mars Will Launch Next Year",
+            "description": "\"SpaceX founder Elon Musk has said his Starship rocket will head to Mars by the end of next year,\" writes the BBC, \"as the company investigates several recent explosions in flight tests.\"\n\nHuman landings could begin as early as 2029 if initial missions go wel…",
+            "url": "https://science.slashdot.org/story/25/03/15/1947252/elon-musk-says-spacexs-first-mission-to-mars-will-launch-next-year",
+            "urlToImage": "https://a.fsdn.com/sd/topics/mars_64.png",
+            "publishedAt": "2025-03-15T20:34:00Z",
+            "content": "Human landings could begin as early as 2029 if initial missions go well, though \"2031 was more likely\", he added in a post on his social media platform X...The billionaire said in 2020 that he remain… [+324 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": "David Shepardson",
+            "title": "US senator asks Rubio to answer questions on planned Tesla Cybertruck purchase",
+            "description": "WASHINGTON (Reuters) -Democratic Senator Richard Blumenthal on Monday asked U.S. Secretary of State Marco Rubio to answer questions about a reported plan to ...",
+            "url": "https://ca.news.yahoo.com/us-senator-asks-rubio-answer-204057277.html",
+            "urlToImage": "https://media.zenfs.com/en/reuters.com/7656f3e47ccfd378997bafb23b9f433e",
+            "publishedAt": "2025-03-03T20:40:57Z",
+            "content": "By David Shepardson\r\nWASHINGTON (Reuters) -Democratic Senator Richard Blumenthal on Monday asked U.S. Secretary of State Marco Rubio to answer questions about a reported plan to spend $400 million to… [+1834 chars]"
+        },
+        {
+            "source": {
+                "id": "abc-news",
+                "name": "ABC News"
+            },
+            "author": "Jon Haworth",
+            "title": "Arsonist sets fire to Tesla charging stations: Police",
+            "description": "Police in Massachusetts are investigating fires that appear to have been “intentionally set” that destroyed seven Tesla charging stations, police said.",
+            "url": "https://abcnews.go.com/US/arsonist-sets-fire-tesla-charging-stations-police/story?id=119417919",
+            "urlToImage": "https://i.abcnewsfe.com/a/c44c55a2-7b3c-44fe-9b20-cf9defd91370/tesla-charging-file_1741080011756_hpMain_16x9.jpg?w=1600",
+            "publishedAt": "2025-03-04T09:37:01Z",
+            "content": "Police in Massachusetts are investigating fires that appear to have been intentionally set that destroyed seven Tesla charging stations, police said.\r\nThe fires were first reported at approximately 1… [+2677 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Xataka.com"
+            },
+            "author": "Alberto de la Torre",
+            "title": "Las ventas de Tesla en Europa se han hundido un 45% y sus acciones lo están pagando caro. Ni siquiera es su peor noticia",
+            "description": "El inicio de 2025 no está siendo el mejor para Tesla. Las ventas de coches eléctricos en Europa se han disparado el pasado mes de enero pero sus ventas han caído hasta niveles preocupantes. Las perspectivas para los inversores no son buenas. Estos son los dat…",
+            "url": "https://www.xataka.com/movilidad/ventas-tesla-europase-han-desplomado-45-sus-acciones-estan-pagando-muy-caro-no-su-peor-noticia",
+            "urlToImage": "https://i.blogs.es/1f430a/tesla-model_y-2025-hd-a105549f1baa6acae656a7f13b2530ab413b1aba5/840_560.jpeg",
+            "publishedAt": "2025-02-27T15:01:56Z",
+            "content": "El inicio de 2025 no está siendo el mejor para Tesla. Las ventas de coches eléctricos en Europa se han disparado el pasado mes de enero pero sus ventas han caído hasta niveles preocupantes. Las persp… [+6248 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Xataka.com"
+            },
+            "author": "Alberto de la Torre",
+            "title": "Tesla tiene un grave problema: sus acciones están cayendo en picado desde el comienzo del año y cada día van a peor",
+            "description": "Cuando escribimos estas líneas, una acción de Tesla cuesta 222 dólares. La cifra ya es inferior a la registrada el 5 de noviembre de 2024, día en el que se celebraron las elecciones de Estados Unidos. Y está muy cerca de igualar los 213 dólares que costaba un…",
+            "url": "https://www.xataka.com/movilidad/luna-miel-tesla-ha-terminado-sus-acciones-se-han-comido-todo-beneficio-ganado-elecciones-estados-unidos",
+            "urlToImage": "https://i.blogs.es/b2cf66/acciones-tesla-marzo/840_560.jpeg",
+            "publishedAt": "2025-03-11T16:15:47Z",
+            "content": "Cuando escribimos estas líneas, una acción de Tesla cuesta 222 dólares. La cifra ya es inferior a la registrada el 5 de noviembre de 2024, día en el que se celebraron las elecciones de Estados Unidos… [+5956 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Xataka.com"
+            },
+            "author": "Javier Lacort",
+            "title": "La ambición política de Musk ha convertido a Tesla en un pararrayos ideológico. Y toda la empresa lo está pagando",
+            "description": "La acción de Tesla tocó su máximo histórico a finales de 2024, justo a tiempo para las navidades. Desde entonces solo ha hecho que recibir carbón, una paradoja para el líder de la transición eléctrica. De 480 dólares a 240. La mitad.\n<!-- BREAK 1 -->\nUn 50% d…",
+            "url": "https://www.xataka.com/empresas-y-economia/ambicion-politica-musk-ha-convertido-a-tesla-pararrayos-ideologico-toda-empresa-esta-pagando",
+            "urlToImage": "https://i.blogs.es/bc41ee/9089440/840_560.jpeg",
+            "publishedAt": "2025-03-16T10:00:43Z",
+            "content": "La acción de Tesla tocó su máximo histórico a finales de 2024, justo a tiempo para las navidades. Desde entonces solo ha hecho que recibir carbón, una paradoja para el líder de la transición eléctric… [+5053 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Xataka.com"
+            },
+            "author": "Ricardo Aguilar",
+            "title": "El Tesla Roadster es un castillo en el aire, así que dos ex-ingenieros de Tesla han decidido crear el suyo",
+            "description": "Llevamos oyendo hablar del Tesla Roadster desde 2017. Han pasado casi diez años y el superdeportivo de Tesla no hace más que retrasarse, habiéndose prometido que empezaría a fabricarse en 2022, 2024, y actualmente sin noticias de ningún tipo sobre su salto a …",
+            "url": "https://www.xataka.com/movilidad/tesla-roadster-castillo-aire-asi-que-dos-ex-ingenieros-tesla-han-decidido-crear-suyo",
+            "urlToImage": "https://i.blogs.es/e0e63e/longbvow/840_560.jpeg",
+            "publishedAt": "2025-03-15T10:46:41Z",
+            "content": "Llevamos oyendo hablar del Tesla Roadster desde 2017. Han pasado casi diez años y el superdeportivo de Tesla no hace más que retrasarse, habiéndose prometido que empezaría a fabricarse en 2022, 2024,… [+2881 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": null,
+            "title": "Tesla Is Flailing in China and the Rapid Rise of BYD Is to Blame",
+            "description": null,
+            "url": "https://consent.yahoo.com/v2/collectConsent?sessionId=1_cc-session_380db15c-b157-4ef3-9926-4979b55777bd",
+            "urlToImage": null,
+            "publishedAt": "2025-03-09T21:00:00Z",
+            "content": "If you click 'Accept all', we and our partners, including 238 who are part of the IAB Transparency &amp; Consent Framework, will also store and/or access information on a device (in other words, use … [+702 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": null,
+            "title": "People Zoomed Into Donald Trump's Tesla Sales Pitch And Can't Believe What They're Seeing",
+            "description": null,
+            "url": "https://consent.yahoo.com/v2/collectConsent?sessionId=1_cc-session_0a4a6dcb-de8d-4719-a75c-45b6cb35c086",
+            "urlToImage": null,
+            "publishedAt": "2025-03-12T15:06:20Z",
+            "content": "If you click 'Accept all', we and our partners, including 238 who are part of the IAB Transparency &amp; Consent Framework, will also store and/or access information on a device (in other words, use … [+702 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": null,
+            "title": "Tesla investors furious at stock’s plunge turn tables on CEO Elon Musk",
+            "description": null,
+            "url": "https://consent.yahoo.com/v2/collectConsent?sessionId=1_cc-session_7360935f-5f77-46f3-affc-6c1f110591b3",
+            "urlToImage": null,
+            "publishedAt": "2025-02-27T18:26:15Z",
+            "content": "If you click 'Accept all', we and our partners, including 238 who are part of the IAB Transparency &amp; Consent Framework, will also store and/or access information on a device (in other words, use … [+702 chars]"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Yahoo Entertainment"
+            },
+            "author": null,
+            "title": "Tesla (TSLA) Maintains “Buy” Rating as AI and Robotics Drive Growth Potential",
+            "description": null,
+            "url": "https://consent.yahoo.com/v2/collectConsent?sessionId=1_cc-session_6bfbe611-b9a4-4bb5-b19d-22afbd574fca",
+            "urlToImage": null,
+            "publishedAt": "2025-03-08T20:57:19Z",
+            "content": "If you click 'Accept all', we and our partners, including 238 who are part of the IAB Transparency &amp; Consent Framework, will also store and/or access information on a device (in other words, use … [+702 chars]"
+        }
+    ]
+}


### PR DESCRIPTION
Created the endpoint '/api/generate_articles' in routes.py. 
This endpoint gathers query from POST request and uses it to query NewsAPI. 
For now, page size is hard coded to 5 and domains only includes theverge.com. 
NewsApi response is processed to gather article data (title, author, date, url).
This reponse is passed to a util function, scrape_summarize in utils.py.
In this function, URL is extracted and is passed to scraper.py to use BeautifulSoup to scrape the website. (Currently only works with theverge.com)
Scraper returns the article content. Content is summarized using our ai_client object created in gemini.py.
Gemini is prompted to generate a summary for the article content.
Summary data is returned to utils.py and we create a new field in our JSON to store this summarization.
Full data is returned to the main endpoint call. Processed articles is extracted from the JSON.
Perform schema validation on the articles, then insert into db.

I created an index on the URL key that is unique. This ensures that articles with the same URL will not be inserted.