### PR TITLE
Update generate_articles and insert_articles endpoints

### DIFF
--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -11,7 +11,7 @@ class ArticleSchema(Schema):
         
     id = fields.Str(dump_only=True, attribute='_id')
     title = fields.Str(required=True)
-    author = fields.Str()
+    author = fields.Str(allow_none=True, missing="No Author")
     published_date = fields.DateTime()
     url = fields.Url(required=True)
     summarization = fields.Nested(SummarizationSchema)


### PR DESCRIPTION
-Refactored the way to insert articles into mongodb. Now uses UpdateOne with upsert = true. This will update existing articles if URL's are matching. If a matching URL is not found, then insert the article. This gracefully handles duplicate articles.
-Changed author schema field to allow missing values
-scrape_summarize in utils.py now tracks failed scrapes. Failed scrapes are printed to the server and the URLs are removed from from the return.
-Endpoints return more information (num_inserted, num_updated, num_processed, num_failed)